### PR TITLE
Annotate images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,5 +171,5 @@ cython_debug/
 .pypirc
 
 # Datasets
-resources/
-resources/*
+data/
+data/*

--- a/main.py
+++ b/main.py
@@ -1,0 +1,13 @@
+from scripts.annotate_images import process_images
+
+if __name__ == "__main__":
+    IMAGE_FOLDER = ""
+    IMAGE_EXT = ""
+    MASK_FOLDER = ""
+    MASK_EXT = ""
+    OUTPUT_FOLDER = ""
+    CLASS_INDEX = 0
+
+    process_images(
+        IMAGE_FOLDER, IMAGE_EXT, MASK_FOLDER, MASK_EXT, OUTPUT_FOLDER, CLASS_INDEX
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ ultralytics
 numpy
 torch
 torchvision
+torchaudio
 opencv-python
 matplotlib

--- a/scripts/annotate_images.py
+++ b/scripts/annotate_images.py
@@ -1,6 +1,7 @@
 import os
 import torch
 import numpy as np
+from torchvision.io import read_image, ImageReadMode
 
 device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
 
@@ -53,3 +54,24 @@ def save_bbox(txt_path: str, line: str) -> None:
     txt_path = txt_path + ".txt"
     with open(txt_path, "w") as myfile:
         myfile.write(line + "\n")
+
+
+# Calculate bounding box coordinates
+def valRect(coord: torch.Tensor) -> list:
+    """
+    Calculate bounding box coordinates from a list of coordinates (x, y) of a mask object
+
+    Args:
+        coord (np.ndarray): List of coordinates (x, y) of a mask object in a binary mask with shape (n, 1, 2) where:
+                            n: number of pixels in the mask object
+                            1: number of channels
+                            2: x and y coordinates
+
+    Returns:
+        list: Returns a list with the coordinates of the bounding box [xmin, ymin, xmax, ymax]
+    """
+    xmin = torch.min(coord[:, 0]) + 1
+    ymin = torch.min(coord[:, 1]) + 1
+    xmax = torch.max(coord[:, 0]) + 1
+    ymax = torch.max(coord[:, 1]) + 1
+    return [xmin.item(), ymin.item(), xmax.item(), ymax.item()]

--- a/scripts/annotate_images.py
+++ b/scripts/annotate_images.py
@@ -39,3 +39,17 @@ def create_dir(path: str) -> None:
             os.makedirs(path)
     except OSError:
         print(f"Error: Creating directory. {path}")
+
+
+# Save bounding box in YOLO format
+def save_bbox(txt_path: str, line: str) -> None:
+    """
+    Save bounding box in YOLO format in a txt file with the specified path
+
+    Args:
+        txt_path (str): Path to save the txt file
+        line (str): Parameters of the bounding box in YOLO format
+    """
+    txt_path = txt_path + ".txt"
+    with open(txt_path, "w") as myfile:
+        myfile.write(line + "\n")

--- a/scripts/annotate_images.py
+++ b/scripts/annotate_images.py
@@ -1,0 +1,26 @@
+import os
+import torch
+import numpy as np
+
+device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
+
+
+# Detect images in a folder an return a sorted list of images path
+def detect_imgs(infolder: str, ext: str = ".png") -> np.ndarray:
+    """
+    Returns a sorted list of images path with some extension (.png as default) in a directory path
+
+    Args:
+        infolder (str): Images path
+        ext (str, optional): Extension of images. Defaults to ".png".
+
+    Returns:
+        np.ndarray: Sorted list of image paths
+    """
+    items = os.listdir(infolder)
+    flist = [
+        os.path.join(infolder, names)
+        for names in items
+        if names.endswith(ext) or names.endswith(ext.upper())
+    ]
+    return np.sort(flist)

--- a/scripts/annotate_images.py
+++ b/scripts/annotate_images.py
@@ -75,3 +75,25 @@ def valRect(coord: torch.Tensor) -> list:
     xmax = torch.max(coord[:, 0]) + 1
     ymax = torch.max(coord[:, 1]) + 1
     return [xmin.item(), ymin.item(), xmax.item(), ymax.item()]
+
+
+# Convert bounding box to YOLO format
+def yolo_format(class_index: int, coord: torch.Tensor, width: int, height: int) -> str:
+    """
+    Convert bounding box coordinates to YOLO format using the coordinates calculated from the mask object in the valRect function
+
+    Args:
+        class_index (int): Index of the class
+        coord (np.ndarray): List of coordinates (x, y) of a mask object in a binary mask with shape (n, 1, 2)
+        width (int): With of the all image
+        height (int): Height of the all image
+
+    Returns:
+        str: Returns a string with the bounding box coordinates in YOLO format rounded to 6 decimal places
+    """
+    [xmin, ymin, xmax, ymax] = valRect(coord)
+    x_center = (xmin + xmax) / (2.0 * width)
+    y_center = (ymin + ymax) / (2.0 * height)
+    x_width = (xmax - xmin) / width
+    y_height = (ymax - ymin) / height
+    return f"{class_index} {x_center:.6f} {y_center:.6f} {x_width:.6f} {y_height:.6f}"

--- a/scripts/annotate_images.py
+++ b/scripts/annotate_images.py
@@ -97,3 +97,56 @@ def yolo_format(class_index: int, coord: torch.Tensor, width: int, height: int) 
     x_width = (xmax - xmin) / width
     y_height = (ymax - ymin) / height
     return f"{class_index} {x_center:.6f} {y_center:.6f} {x_width:.6f} {y_height:.6f}"
+
+
+# Main function to call and process images
+def process_images(
+    image_folder: str,
+    image_ext: str,
+    mask_folder: str,
+    mask_ext: str,
+    output_folder: str,
+    class_index: int = 0,  # Only allows one class
+) -> None:
+    """
+    Call all necessary functions to create the directory, get the coordinates, calculate the bounding box in YOLO format, and save the .txt file
+
+    Args:
+        image_folder (str): Directory path to images
+        mask_folder (str): Directory path to masks
+        output_folder (str): Directory path to save the .txt files
+        class_index (int, optional): Index object classes. Defaults to 0.
+    """
+    create_dir(output_folder)  # Create output directory
+
+    images = detect_imgs(image_folder, image_ext)  # Detect images in the folder
+    masks = detect_imgs(mask_folder, mask_ext)  # Detect masks in the folder
+
+    for img_path, mask_path in zip(
+        images, masks
+    ):  # Iterates and uncompress every path of images and masks
+        image = read_image(img_path).to(device)  # Read image
+        mask = read_image(mask_path, mode=ImageReadMode.GRAY).to(
+            device
+        )  # Read mask in grayscale
+
+        h, w = image.shape[1], image.shape[2]  # Get image shape
+
+        mask_coordinates = torch.nonzero(mask.squeeze(), as_tuple=False)[
+            :, [1, 0]
+        ]  # Find non-zero coordinates in the mask and reverse the order
+
+        # If no objects found in the mask, skip the image
+        if mask_coordinates.size(0) == 0:
+            print(f"No objects found in mask: {mask_path}")
+            continue
+
+        # Convert mask coordinates to YOLO format
+        yolo_line = yolo_format(class_index, mask_coordinates, w, h)
+
+        # Save bounding box in YOLO format
+        base_name = os.path.splitext(os.path.basename(img_path))[0]
+        output_txt_path = os.path.join(output_folder, base_name)
+        save_bbox(output_txt_path, yolo_line)
+
+        print(f"Processed: {img_path} -> {output_txt_path}")

--- a/scripts/annotate_images.py
+++ b/scripts/annotate_images.py
@@ -24,3 +24,18 @@ def detect_imgs(infolder: str, ext: str = ".png") -> np.ndarray:
         if names.endswith(ext) or names.endswith(ext.upper())
     ]
     return np.sort(flist)
+
+
+# Create directory if no exists
+def create_dir(path: str) -> None:
+    """
+    Create directory if no exists
+
+    Args:
+        path (str): Directory path
+    """
+    try:
+        if not os.path.exists(path):
+            os.makedirs(path)
+    except OSError:
+        print(f"Error: Creating directory. {path}")


### PR DESCRIPTION
This pull request includes significant additions to the `main.py` and `scripts/annotate_images.py` files to introduce functionality for processing images and masks, and saving bounding boxes in YOLO format.

New functionality for image processing:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R1-R13): Added a new script that imports `process_images` from `scripts.annotate_images` and sets up necessary variables to call this function.

* [`scripts/annotate_images.py`](diffhunk://#diff-b82bf1c6e1bf8478d648272903a249b3a1da87076ba5334b5e28a46fdf3728b1R1-R152): Introduced multiple functions to handle image processing tasks, including detecting images, creating directories, saving bounding boxes, calculating bounding box coordinates, converting bounding boxes to YOLO format, and a main function (`process_images`) to orchestrate these tasks.

Key functions added:
  * `detect_imgs`: Detects images in a folder and returns a sorted list of image paths.
  * `create_dir`: Creates a directory if it does not exist.
  * `save_bbox`: Saves bounding box coordinates in YOLO format to a text file.
  * `valRect`: Calculates bounding box coordinates from a list of mask object coordinates.
  * `yolo_format`: Converts bounding box coordinates to YOLO format.